### PR TITLE
bugfix: fix an index out of range error occurring in most github tables

### DIFF
--- a/extensions/internal/github/org_repos.go
+++ b/extensions/internal/github/org_repos.go
@@ -255,6 +255,9 @@ func (i *iterOrgRepos) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(results.OrgRepos) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/repo_branch_protection.go
+++ b/extensions/internal/github/repo_branch_protection.go
@@ -163,10 +163,10 @@ func (i *iterProtections) Next() (vtab.Row, error) {
 
 			i.results = results
 			i.current = 0
-			if len(i.results.Edges) == 0 {
-				return i.Next()
-			}
 
+			if len(i.results.Edges) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/repo_issues.go
+++ b/extensions/internal/github/repo_issues.go
@@ -219,6 +219,9 @@ func (i *iterIssues) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(results.Edges) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/repo_prs.go
+++ b/extensions/internal/github/repo_prs.go
@@ -268,6 +268,9 @@ func (i *iterPRs) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(results.Edges) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/stargazers.go
+++ b/extensions/internal/github/stargazers.go
@@ -155,6 +155,9 @@ func (i *iterStargazers) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(i.results.Edges) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/starred_repos.go
+++ b/extensions/internal/github/starred_repos.go
@@ -150,6 +150,9 @@ func (i *iterStarredRepos) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(i.results.Edges) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}

--- a/extensions/internal/github/user_repos.go
+++ b/extensions/internal/github/user_repos.go
@@ -255,6 +255,9 @@ func (i *iterUserRepos) Next() (vtab.Row, error) {
 			i.results = results
 			i.current = 0
 
+			if len(i.results.UserRepos) == 0 {
+				return nil, io.EOF
+			}
 		} else {
 			return nil, io.EOF
 		}


### PR DESCRIPTION
happens when the page of results from an API request is empty