### PR TITLE
rm some checks

### DIFF
--- a/extensions/internal/helpers/grep.go
+++ b/extensions/internal/helpers/grep.go
@@ -40,10 +40,7 @@ func NewGrepModule() sqlite.Module {
 			}
 		}
 
-		if contents == "" {
-			return nil, fmt.Errorf("no contents Provided")
-		}
-
+		// TODO(patrickdevivo) not entirely sure if we should fail/error on this or let it be
 		if search == "" {
 			return nil, fmt.Errorf("no search string provided")
 		}

--- a/extensions/internal/helpers/str_split_tbl.go
+++ b/extensions/internal/helpers/str_split_tbl.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"strings"
 
@@ -33,9 +32,6 @@ func NewStrSplitModule() sqlite.Module {
 			}
 		}
 
-		if contents == "" {
-			return nil, fmt.Errorf("no Contents Provided")
-		}
 		if delimiter == "" {
 			delimiter = "\n"
 		}


### PR DESCRIPTION
should be fine to pass an empty string to grep or split, as that's more like a "base" or "noop" case. It also prevents errors in queries where the contents are dynamically supplied (a column in another table) and one "poison" empty string causes an error in the entire query.