### PR TITLE
fix: clone sub modules when running renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,5 @@
   "extends": [
     "config:base"
   ],
-  "postUpdateOptions": ["gomodMassage"]
+  "cloneSubmodules": true
 }


### PR DESCRIPTION
Hopefully this addresses the issues with the `renovate` PRs