### PR TITLE
fix: failing test cases that uses `github.com/mergestat/mergestat`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint:
 	golangci-lint run --build-tags $(TAGS)
 
 lint-ci:
-	./bin/golangci-lint run --build-tags $(TAGS) --out-format github-actions
+	./bin/golangci-lint run --build-tags $(TAGS) --out-format github-actions --timeout 5m
 
 test:
 	go test -v -tags=$(TAGS) ./...

--- a/extensions/internal/git/log_test.go
+++ b/extensions/internal/git/log_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSelectAllCommits(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, ref := "https://github.com/mergestat/mergestat", "HEAD"
+	repo, ref := "https://github.com/mergestat/mergestat-lite", "HEAD"
 
 	rows, err := db.Query("SELECT * FROM commits(?, ?) LIMIT 5", repo, ref)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestSelectAllCommits(t *testing.T) {
 
 func TestSelectCommitByHash(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, ref := "https://github.com/mergestat/mergestat", "HEAD"
+	repo, ref := "https://github.com/mergestat/mergestat-lite", "HEAD"
 	hash := "5ce802c851d3bedb5bb4a0f749093cae9a34818b"
 
 	var message, email string
@@ -52,7 +52,7 @@ func TestSelectCommitByHash(t *testing.T) {
 
 func TestDateFilterOnCommit(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT hash, committer_email, committer_when FROM commits(?)"+
 		"	WHERE committer_when > DATE(?) AND committer_when < DATE(?) ORDER BY committer_when DESC",
@@ -78,7 +78,7 @@ func TestDateFilterOnCommit(t *testing.T) {
 
 func TestDefaultCases(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	var q = func(row *sql.Row) (hash, email string, when time.Time, err error) {
 		err = row.Scan(&hash, &email, &when)

--- a/extensions/internal/git/native/blame_test.go
+++ b/extensions/internal/git/native/blame_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSelectBlameREADMELines(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT line_no, commit_hash FROM blame(?, '', 'README.md') LIMIT 10", repo)
 	if err != nil {
@@ -35,7 +35,7 @@ func TestSelectBlameREADMELines(t *testing.T) {
 
 func TestSelectKnownBlame(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, hash := "https://github.com/mergestat/mergestat", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5"
+	repo, hash := "https://github.com/mergestat/mergestat-lite", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5"
 
 	rows, err := db.Query("SELECT line_no, commit_hash FROM blame(?, ?, 'README.md')", repo, hash)
 	if err != nil {

--- a/extensions/internal/git/native/files_test.go
+++ b/extensions/internal/git/native/files_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSelect10FilesHEAD(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT path, executable, contents FROM files(?) LIMIT 10", repo)
 	if err != nil {
@@ -33,7 +33,7 @@ func TestSelect10FilesHEAD(t *testing.T) {
 
 func TestSelectKnownContents(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, hash := "https://github.com/mergestat/mergestat", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5"
+	repo, hash := "https://github.com/mergestat/mergestat-lite", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5"
 
 	rows, err := db.Query("SELECT path, contents FROM files(?, ?) WHERE path LIKE 'Makefile' OR path LIKE 'go.mod'", repo, hash)
 	if err != nil {

--- a/extensions/internal/git/native/stats_test.go
+++ b/extensions/internal/git/native/stats_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSelectLast5CommitStats(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT commits.hash, file_path, additions, deletions FROM commits($1), stats($1, commits.hash) LIMIT 5", repo)
 	if err != nil {
@@ -31,7 +31,7 @@ func TestSelectLast5CommitStats(t *testing.T) {
 
 func TestInitialCommitStats(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, initialCommit := "https://github.com/mergestat/mergestat", "a4562d2d5a35536771745b0aa19d705eb47234e7"
+	repo, initialCommit := "https://github.com/mergestat/mergestat-lite", "a4562d2d5a35536771745b0aa19d705eb47234e7"
 
 	var filesChanged, additions, deletions int
 	err := db.QueryRow("SELECT count(DISTINCT file_path), sum(additions), sum(deletions) FROM stats(?, ?)", repo, initialCommit).
@@ -59,7 +59,7 @@ func TestInitialCommitStats(t *testing.T) {
 
 func TestFromAndToStats(t *testing.T) {
 	db := Connect(t, Memory)
-	repo, fromHash, toHash := "https://github.com/mergestat/mergestat", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5", "d65736fd08fab5a64027f0c050ee148d88549406"
+	repo, fromHash, toHash := "https://github.com/mergestat/mergestat-lite", "2359c9a9ba0ba8aa694601ff12538c4e74b82cd5", "d65736fd08fab5a64027f0c050ee148d88549406"
 
 	var filesChanged, additions, deletions int
 	err := db.QueryRow("SELECT count(DISTINCT file_path), sum(additions), sum(deletions) FROM stats(?, ?, ?)", repo, fromHash, toHash).

--- a/extensions/internal/git/refs_func_test.go
+++ b/extensions/internal/git/refs_func_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCommitFromTagFn(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT name, full_name, COMMIT_FROM_TAG(tag) FROM refs(?) WHERE type = 'tag'", repo)
 	if err != nil {

--- a/extensions/internal/git/refs_test.go
+++ b/extensions/internal/git/refs_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSelectAllRefs(t *testing.T) {
 	db := Connect(t, Memory)
-	repo := "https://github.com/mergestat/mergestat"
+	repo := "https://github.com/mergestat/mergestat-lite"
 
 	rows, err := db.Query("SELECT * FROM refs(?)", repo)
 	if err != nil {


### PR DESCRIPTION
as a fixture repo. Now that the repo has been renamed, we should use `github.com/mergestat/mergestat-lite` to look for the SHAs or related objects we expect.