### PR TITLE
commit summary fails on 'author_email' being NULL

### DIFF
--- a/cmd/summarize/commits/commits.go
+++ b/cmd/summarize/commits/commits.go
@@ -60,14 +60,14 @@ SELECT
 `
 
 type CommitAuthorSummary struct {
-	AuthorName    string        `db:"author_name"`
-	AuthorEmail   string        `db:"author_email"`
-	Commits       int           `db:"commit_count"`
-	Additions     sql.NullInt64 `db:"additions"`
-	Deletions     sql.NullInt64 `db:"deletions"`
-	DistinctFiles int           `db:"distinct_files"`
-	FirstCommit   string        `db:"first_commit"`
-	LastCommit    string        `db:"last_commit"`
+	AuthorName    string         `db:"author_name"`
+	AuthorEmail   sql.NullString `db:"author_email"`
+	Commits       int            `db:"commit_count"`
+	Additions     sql.NullInt64  `db:"additions"`
+	Deletions     sql.NullInt64  `db:"deletions"`
+	DistinctFiles int            `db:"distinct_files"`
+	FirstCommit   string         `db:"first_commit"`
+	LastCommit    string         `db:"last_commit"`
 }
 
 const commitAuthorSummarySQL = `
@@ -188,6 +188,7 @@ func (t *TermUI) loadCommitSummary() tea.Msg {
 	}
 
 	var commitSummary CommitSummary
+
 	if err := t.db.QueryRowx(commitSummarySQL, sql.Named("file_path", pathPattern)).StructScan(&commitSummary); err != nil {
 		return err
 	}


### PR DESCRIPTION
Before change:
```
devzero@ngvzugqq mergestat-lite (main) $ make .build/mergestat && .build/mergestat -r ../services/ summarize commits --verbose
-- building .build/mergestat
-- built .build/mergestat
May 15 18:03:02 INF opening repo path=../services/
May 15 18:03:48 ERR sql: Scan error on column index 1, name "author_email": converting NULL to string is unsupported
```

After change:
```
devzero@ngvzugqq mergestat-lite (main) $ make .build/mergestat && .build/mergestat -r ../services/ summarize commits --verbose
-- building .build/mergestat
-- built .build/mergestat
May 15 18:06:50 INF opening repo path=../services/
wunderwuzzi23         88        3.49%      49        27,351      14,622      3 years ago (2021-05-05)   
```