### PR TITLE
fix: add warning for mixed casing in FROM and AS keywords

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster as builder
+FROM golang:1.19-buster AS builder
 WORKDIR /app
 RUN apt-get update && apt-get -y install cmake libssl-dev
 COPY . .


### PR DESCRIPTION
This PR adds a warning for the `FromAsCasing` rule, addressing the issue of inconsistent casing between the `FROM` and `AS` keywords in Dockerfiles. The rule enforces consistent casing for readability and maintainability, providing a warning message when mixed casing occurs.

### Changes:

- Added a warning message:  
  `WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line X)`

### Examples:

❌ **Bad:** `FROM` is uppercase, `AS` is lowercase.   `FROM debian:latest as builder`

✅ Good: FROM and AS are both uppercase.
`FROM debian:latest AS deb-builder`

✅ Good: FROM and AS are both lowercase.
`from debian:latest as deb-builder`

For more information, refer to the Dockerfile checks documentation: [Dockerfile FROM-AS Casing](https://docs.docker.com/reference/build-checks/from-as-casing/