### PR TITLE
fix an error when exporting more than 3 tables

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -44,7 +44,7 @@ var exportCmd = &cobra.Command{
 			if e == 0 {
 				pairs[e] = export{exports[e], exports[e+1]}
 			} else {
-				pairs[e-1] = export{exports[e], exports[e+1]}
+				pairs[e/2] = export{exports[e], exports[e+1]}
 			}
 		}
 


### PR DESCRIPTION
Fixed the following error when exporting more than 3 tables

```
$ mergestat export file -e refs -e "SELECT * FROM refs" -e commits -e "SELECT * FROM commits" -e stat -e "SELECT * FROM stats"
panic: runtime error: index out of range [3] with length 3

goroutine 1 [running]:
github.com/mergestat/mergestat-lite/cmd.glob..func1(0x215cd60, {0xc001159380, 0x1, 0xd?})
        /home/runner/work/mergestat-lite/mergestat-lite/cmd/export.go:47 +0x9a5
github.com/spf13/cobra.(*Command).execute(0x215cd60, {0xc0011592b0, 0xd, 0xd})                                                                                                                                                                      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xa9b
github.com/spf13/cobra.(*Command).ExecuteC(0x215d320)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x425
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/mergestat/mergestat-lite/cmd.Execute()
        /home/runner/work/mergestat-lite/mergestat-lite/cmd/root.go:155 +0x25
main.main()
        /home/runner/work/mergestat-lite/mergestat-lite/mergestat.go:8 +0x17
```